### PR TITLE
Generate cloud regions

### DIFF
--- a/.github/workflows/get-cloud-api-spec.yaml
+++ b/.github/workflows/get-cloud-api-spec.yaml
@@ -55,6 +55,12 @@ jobs:
           npx doc-tools fetch -o redpanda-data -r cloudv2 -p proto/gen/openapi/openapi.dataplane.prod.yaml -d  cloud-dataplane -f cloud-dataplane.yaml
         env:
           VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+      - name: Generate cloud regions
+        working-directory: redpanda-docs
+        run: |
+          npx doc-tools generate cloud-regions
+        env:
+          GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "4.6.12",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-4.6.12.tgz",
-      "integrity": "sha512-dfTGMFCtVySUNBmO/xA0T582AFG9gWGJ8lBzAMS/dx8CURDmvqZQiD/oAFfa3YPEKnzeAS1/Ce+GZamtLTRe5A==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-4.7.0.tgz",
+      "integrity": "sha512-E/dzevwpp8/3hKTyM2UUsd0DLz1o8zuJBwQP2+D8dg7jTlbgM6lfNTNupRWJRTP3M4FCeqL8SDralYdbt2zr8g==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",


### PR DESCRIPTION
This pull request adds a new step to the GitHub Actions workflow for generating cloud regions documentation. This helps automate the process of keeping cloud region data up to date.

**Workflow automation:**

* Added a `Generate cloud regions` step to the `.github/workflows/get-cloud-api-spec.yaml` workflow, running `npx doc-tools generate cloud-regions` in the `redpanda-docs` directory. This step ensures that cloud region documentation is generated automatically as part of the workflow.