### PR TITLE
Update Data Plane API spec server URL and variable

### DIFF
--- a/cloud-dataplane/cloud-dataplane.yaml
+++ b/cloud-dataplane/cloud-dataplane.yaml
@@ -4978,9 +4978,9 @@ servers:
     url: 'https://{dataplane_api_url}.cloud.redpanda.com'
     variables:
       dataplane_api_url:
-        default: ""
+        default: "dataplane_api.url"
         description: |-
-          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url field is returned in the response body. This field is required and there is no default value.<br><br>
+          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url field is returned in the response body.<br><br>
           Example (Dedicated): "https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com"<br>
           Example (BYOC): "https://api-a4cb21.ck09mi9c4vs17hng9gig.byoc.prd.cloud.redpanda.com"
 tags:

--- a/cloud-dataplane/cloud-dataplane.yaml
+++ b/cloud-dataplane/cloud-dataplane.yaml
@@ -4975,14 +4975,14 @@ security:
   - auth0: []
 servers:
   - description: Data Plane API
-    url: '{dataplane_api_url}'
+    url: 'https://{dataplane_api_url}.cloud.redpanda.com'
     variables:
       dataplane_api_url:
-        default: https://{dataplane_api_url}
+        default: ""
         description: |-
-          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url field is returned in the response body.<br><br>
-          					Example (Dedicated): "https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com"<br>
-          					Example (BYOC): "https://api-a4cb21.ck09mi9c4vs17hng9gig.byoc.prd.cloud.redpanda.com"
+          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url field is returned in the response body. This field is required and there is no default value.<br><br>
+          Example (Dedicated): "https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com"<br>
+          Example (BYOC): "https://api-a4cb21.ck09mi9c4vs17hng9gig.byoc.prd.cloud.redpanda.com"
 tags:
   - description: Manage Redpanda access control lists (ACLs). See [Redpanda Cloud Authorization](https://docs.redpanda.com/redpanda-cloud/security/authorization/cloud-authorization/) for more information.
     name: Redpanda ACLs


### PR DESCRIPTION
Change server url values and variables to work with Bump API explorer proxy, per Bump's request:

> We currently have a proxy in the API Explorer to resolve potential CORS issues ([Details in our help center](https://docs.bump.sh/help/documentation-experience/api-explorer/#proxy)). As we don’t want it to become an open proxy, it only works with domains defined in the OpenAPI definition file. By keeping the whole server as a variable (url: '{dataplane_api_url}') in your Data Plane API definition file, our proxy can’t determine the allowed domain and will block the request.
Would it be possible to define the static part of the URL, and only have the specific part as a variable? For example url: "{dataplane_api_url}.[redpanda.com](http://redpanda.com/)" We will add an option to disable the proxy globally at some point (to support local servers, for instance) and let you handle your CORS settings on your end, but that would be the quickest way to have a fully functional API Explorer.

These changes will need to be backported to the source (console).
