### PR TITLE
Clarify auth flows

### DIFF
--- a/cloud-controlplane/x-topics/quickstart.md
+++ b/cloud-controlplane/x-topics/quickstart.md
@@ -62,7 +62,7 @@ If you successfully retrieve an access token, it is valid for one hour. You can 
 
 ### Serverless
 
-1. In the page header, click **API Explorer**.
+1. Open **API Explorer**.
 
 1. On the **Choose an operation** dropdown, select **Create resource group**.
 1. Click **Get token**. You may be prompted to log in to the Redpanda Cloud UI. After you log in, the browser automatically redirects you back to the Create resource group endpoint in the API Explorer.

--- a/cloud-controlplane/x-topics/quickstart.md
+++ b/cloud-controlplane/x-topics/quickstart.md
@@ -24,17 +24,27 @@ If you successfully retrieve an access token, it is valid for one hour. You can 
 
 ### BYOC or Dedicated
 
-1. In the page header, click **API Explorer**.
+1. Open **API Explorer**.
+
 1. On the **Choose an operation** dropdown, select **Create resource group**.
+
 1. Click **Get token**. You may be prompted to log in to the Redpanda Cloud UI. After you log in, the browser automatically redirects you back to the Create resource group endpoint in the API Explorer.
+
 1. Prepare your Create resource group request.
-  1. Under **Body**, click **+ Add** and provide a name for your resource group. A resource group is a container to organize your Redpanda Cloud resources, such as clusters and networks.
-  1. Click **Send request**. If successful, the response returns a resource group ID. Pass this ID when you make a Create network request. 
+
+    1. Under **Body**, click **+ Add** and provide a name for your resource group. A resource group is a container to organize your Redpanda Cloud resources, such as clusters and networks.
+
+    1. Click **Send request**. If successful, the response returns a resource group ID. Pass this ID when you make a Create network request. 
+
 1. On the dropdown, select **Create network**.
+
 1. Prepare your Create network request.
-  1. Include the ID of the resource group you created in the previous step. 
-  1. Click **Send request**. Note that this endpoint returns a long-running operation. The response returns a network ID in `metadata.network_id`. Pass this ID when you call the Create Cluster endpoint.To check the operation state, make a **Get operation** request with the `operation.id`.  
+
+    1. Include the ID of the resource group you created in the previous step. 
+    1. Click **Send request**. Note that this endpoint returns a long-running operation. The response returns a network ID in `metadata.network_id`. Pass this ID when you call the Create Cluster endpoint. To check the operation state, make a **Get operation** request with the `operation.id`.  
+
 1. When the Create network operation is complete, make a Create cluster request. Use the resource group and network IDs you just created. Note that this endpoint also returns a long-running operation.
+
 1. For BYOC, run `rpk cloud byoc` in the shell, passing the `metadata.cluster_id` from the Create cluster response as a flag:
 
    **AWS:**
@@ -53,20 +63,27 @@ If you successfully retrieve an access token, it is valid for one hour. You can 
 ### Serverless
 
 1. In the page header, click **API Explorer**.
+
 1. On the **Choose an operation** dropdown, select **Create resource group**.
 1. Click **Get token**. You may be prompted to log in to the Redpanda Cloud UI. After you log in, the browser automatically redirects you back to the Create resource group endpoint in the API Explorer.
+
 1. Prepare your Create resource group request.
-  1. Under **Body**, click **+ Add** and provide a name for your resource group. A resource group is a container to organize your Redpanda Cloud resources, such as clusters and networks.
-  1. Click **Send request**. If successful, the response returns a resource group ID. Pass this ID later when you make a Create Serverless cluster request. 
-1. On the dropdown, select **Create Serverless cluster**. 
+
+    1. Under **Body**, click **+ Add** and provide a name for your resource group. A resource group is a container to organize your Redpanda Cloud resources, such as clusters and networks.
+    1. Click **Send request**. If successful, the response returns a resource group ID. Pass this ID later when you make a Create Serverless cluster request.
+
+1. On the dropdown, select **Create Serverless cluster**.
+
 1. Prepare your Create Serverless cluster request.
-  1. Make a Get Serverless Regions request to see available regions.
-  1. In the request body, use the resource group ID and desired cloud region.
-  1. Click **Send request**. Note that this endpoint returns a long-running operation. The response returns a Serverless cluster ID in `metadata.cluster_id`. To check the operation state, make a **Get operation** request with the `operation.id`.
+
+    1. Make a Get Serverless Regions request to see available regions.
+    1. In the request body, use the resource group ID and desired cloud region.
+    1. Click **Send request**. Note that this endpoint returns a long-running operation. The response returns a Serverless cluster ID in `metadata.cluster_id`. To check the operation state, make a **Get operation** request with the `operation.id`.
 
 ## Next steps: try the Data Plane APIs
 
 1. Retrieve your cluster's data plane API URL by making a **Get cluster** (BYOC, Dedicated) or **Get Serverless cluster** (Serverless) request in the API Explorer.
+
 1. Save the value of `dataplane_api.url` from the response body.
 1. From the **Redpanda APIs** selector, go to **Cloud Data Plane API**.
 1. Select an operation, for example **Create topic** or **List users**. 

--- a/cloud-dataplane/cloud-dataplane.yaml
+++ b/cloud-dataplane/cloud-dataplane.yaml
@@ -4976,12 +4976,12 @@ security:
   - auth0: []
 servers:
   - description: Data Plane API
-    url: 'https://{dataplane_api_url}.cloud.redpanda.com'
+    url: 'https://{dataplane.api.subdomain}.cloud.redpanda.com'
     variables:
-      dataplane_api_url:
-        default: "dataplane_api.url"
+      dataplane.api.subdomain:
+        default: "dataplane.api.subdomain"
         description: |-
-          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url field is returned in the response body.<br><br>
+          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url value is returned in the response body. The subdomain is unique to each cluster.<br><br>
           Example (Dedicated): "https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com"<br>
           Example (BYOC): "https://api-a4cb21.ck09mi9c4vs17hng9gig.byoc.prd.cloud.redpanda.com"
 tags:

--- a/cloud-dataplane/cloud-dataplane.yaml
+++ b/cloud-dataplane/cloud-dataplane.yaml
@@ -4976,14 +4976,14 @@ security:
   - auth0: []
 servers:
   - description: Data Plane API
-    url: 'https://{dataplane.api.subdomain}.cloud.redpanda.com'
+    url: '{dataplane_api_url}'
     variables:
-      dataplane.api.subdomain:
-        default: "dataplane.api.subdomain"
+      dataplane_api_url:
+        default: https://{dataplane_api_url}
         description: |-
-          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url value is returned in the response body. The subdomain is unique to each cluster.<br><br>
-          Example (Dedicated): "https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com"<br>
-          Example (BYOC): "https://api-a4cb21.ck09mi9c4vs17hng9gig.byoc.prd.cloud.redpanda.com"
+          Find the Data Plane API base URL of a cluster by calling the Get Cluster endpoint of the Control Plane API. The dataplane_api.url field is returned in the response body.<br><br>
+          					Example (Dedicated): "https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com"<br>
+          					Example (BYOC): "https://api-a4cb21.ck09mi9c4vs17hng9gig.byoc.prd.cloud.redpanda.com"
 tags:
   - description: Manage Redpanda access control lists (ACLs). See [Redpanda Cloud Authorization](https://docs.redpanda.com/redpanda-cloud/security/authorization/cloud-authorization/) for more information.
     name: Redpanda ACLs

--- a/cloud-dataplane/overlays/update-dataplane-server-config.yaml
+++ b/cloud-dataplane/overlays/update-dataplane-server-config.yaml
@@ -1,0 +1,21 @@
+# Overlay to update server configuration for Bump API Explorer compatibility.
+# This updates the server URL, variable description to better match usage in API Explorer.
+
+overlay: 1.0.0
+info:
+  title: Update Server Configuration
+  version: 1.0.0
+actions:
+  # Update only the server URL template
+  - target: "$.servers[0].url"
+    update: "https://{dataplane.api.subdomain}.cloud.redpanda.com"
+  
+  # Update only the variables section
+  - target: "$.servers[0].variables"
+    update:
+      dataplane.api.subdomain:
+        default: "dataplane.api.subdomain"
+        description: |-
+          From the `dataplane_api.url` value in the Control Plane API response, extract the subdomain (the part between `https://` and `.cloud.redpanda.com`). Enter this value in the Data Plane API URL field.
+          
+          Example: If the URL is `https://api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd.cloud.redpanda.com`, enter `api-a4cb21.ck09mi9c4vs17hng9gig.fmc.prd`

--- a/cloud-dataplane/overlays/update-dataplane-server-config.yaml
+++ b/cloud-dataplane/overlays/update-dataplane-server-config.yaml
@@ -13,7 +13,7 @@ actions:
   - target: "$.servers[0].variables"
     update:
       dataplane_api_subdomain:
-        default: "dataplane.api.subdomain"
+        default: "{dataplane.api.subdomain}"
         description: |-
           From the `dataplane_api.url` value in the Control Plane API response, extract the subdomain (the part between `https://` and `.cloud.redpanda.com`). Enter this value in the Data Plane API URL field.
           

--- a/cloud-dataplane/overlays/update-dataplane-server-config.yaml
+++ b/cloud-dataplane/overlays/update-dataplane-server-config.yaml
@@ -8,12 +8,11 @@ info:
 actions:
   # Update only the server URL template
   - target: "$.servers[0].url"
-    update: "https://{dataplane.api.subdomain}.cloud.redpanda.com"
-  
+    update: "https://{dataplane_api_subdomain}.cloud.redpanda.com"
   # Update only the variables section
   - target: "$.servers[0].variables"
     update:
-      dataplane.api.subdomain:
+      dataplane_api_subdomain:
         default: "dataplane.api.subdomain"
         description: |-
           From the `dataplane_api.url` value in the Control Plane API response, extract the subdomain (the part between `https://` and `.cloud.redpanda.com`). Enter this value in the Data Plane API URL field.

--- a/cloud-dataplane/x-topics/quickstart.md
+++ b/cloud-dataplane/x-topics/quickstart.md
@@ -20,11 +20,18 @@ If you successfully retrieve an access token, it is valid for one hour. You can 
 
 > **Warning:** API requests from this page are executed against your actual environment and data, not a sandbox.
 
-1. In the page header, click **API Explorer**.
-1. If you don't already have the data plane API URL for your target cluster, make a Get Cluster (BYOC, Dedicated) or Get Serverless Cluster (Serverless) request with the Control Plane API. The response contains the data plane API URL. Copy the value of `dataplane_api.url` from the response body, and enter it in the URL field.
+1. Open **API Explorer**.
+
+1. If you don't already have the data plane API URL for your target cluster, make a Get Cluster (BYOC, Dedicated) or Get Serverless Cluster (Serverless) request with the Control Plane API. The response contains the data plane API URL.
+
+   From the `dataplane_api.url` value in the response, extract only the subdomain (the part between `https://` and `.cloud.redpanda.com`). Enter this value in the Data Plane API URL field.
+
 1. On the **Choose an operation** dropdown, select **Create topic**.
+
 1. Click **Get token**. You may be prompted to log in to the Redpanda Cloud UI. After you log in, the browser automatically redirects you back to the Create resource group endpoint in the API Explorer.
+
 1. Enter a name for your topic and click **Send request**.
+
 1. Confirm that your topic is successfully created by making a List topics request.
 
 ## Next steps

--- a/cloud-dataplane/x-topics/quickstart.md
+++ b/cloud-dataplane/x-topics/quickstart.md
@@ -28,7 +28,7 @@ If you successfully retrieve an access token, it is valid for one hour. You can 
 
 1. On the **Choose an operation** dropdown, select **Create topic**.
 
-1. Click **Get token**. You may be prompted to log in to the Redpanda Cloud UI. After you log in, the browser automatically redirects you back to the Create resource group endpoint in the API Explorer.
+1. If you need a valid access token, click **Get token**. You may be prompted to log in to the Redpanda Cloud UI. After you log in, the browser automatically redirects you back to the Create topic endpoint in the API Explorer.
 
 1. Enter a name for your topic and click **Send request**.
 

--- a/shared/overlays/update-securityschemes-for-authentication.yaml
+++ b/shared/overlays/update-securityschemes-for-authentication.yaml
@@ -7,4 +7,11 @@ info:
 actions:
   - target: $.components.securitySchemes.auth0
     update:
-      description: The Cloud APIs use OAuth 2.0 for authentication. You must create a service account in the Cloud UI in order to request an access token. You can use the same access token to authenticate requests to both the Control Plane and Data Plane APIs.
+      description: |-
+        The Cloud APIs use OAuth 2.0 for authentication.
+        
+        **For API Explorer (browser):** Authentication is handled automatically. Click "Get token" on any endpoint to authenticate with your Redpanda Cloud account and include a bearer token for requests made in API Explorer.
+        
+        **For Programmatic Access (CLI, SDKs, Scripts):** You must create a service account in the Redpanda Cloud UI and use the OAuth 2.0 client credentials flow to obtain an access token. See the Authentication topic for detailed instructions.
+        
+        The same access token can be used for both Control Plane and Data Plane API requests for as long as the token is valid (one hour).

--- a/shared/x-topics/about-authentication.md
+++ b/shared/x-topics/about-authentication.md
@@ -1,10 +1,24 @@
-The Cloud API uses the Client Credentials Flow as defined in [Auth 2.0 RFC 6749, section 4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4O). In Redpanda Cloud, you must first create a **service account** through which you can authenticate requests to the Cloud API. The service account is associated with your Redpanda Cloud organization. The service account acts as an OAuth 2.0 client that provides its credentials (client ID and client secret) to the API authentication server. The authentication server grants an access token in return. You can then include the access token in each request to the API.
-
-The access token granted to you is associated with a specific Redpanda Cloud organization. If you want to use the API for a different organization, you must acquire a new token through a service account with that organization.
+The Redpanda Cloud API uses OAuth 2.0 for authentication. The authentication method depends on whether you access the API in the browser using the API Explorer, or programmatically.
 
 You only need to authenticate once to the Cloud API. That is, after you obtain an access token, you can use the same token in requests to both Control Plane and Data Plane API endpoints, for as long as the token is valid.
 
-## Request an access token
+## Authenticate in API Explorer
+
+When using the API Explorer in your browser, Redpanda Cloud uses the [OAuth 2.0 Implicit Flow](https://datatracker.ietf.org/doc/html/rfc6749#section-4.2):
+
+1. Click **Get token** on any API endpoint.
+2. Log in with your Redpanda Cloud credentials if prompted. After you log in, you are redirected back to the API Explorer.
+3. The token is automatically applied to your API requests.
+
+## Authenticate programmatic requests
+
+For programmatic access (using a CLI, SDKs, and applications), the Cloud API uses the Client Credentials Flow as defined in [Auth 2.0 RFC 6749, section 4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4O). 
+
+You must first create a **service account** through which you can authenticate requests to the Cloud API. The service account is associated with your Redpanda Cloud organization. The service account acts as an OAuth 2.0 client that provides its credentials (client ID and client secret) to the API authentication server. The authentication server grants an access token in return. You can then include the access token in each request to the API.
+
+The access token granted to you is associated with a specific Redpanda Cloud organization. If you want to use the API for a different organization, you must acquire a new token through a service account with that organization.
+
+### Request an access token
 
 Users with administrative privileges in a Redpanda Cloud organization can create a service account.
 
@@ -26,7 +40,7 @@ Users with administrative privileges in a Redpanda Cloud organization can create
 
     The request response provides an access token that remains valid for one hour.
 
-## Authenticate API requests
+### Use the access token in API requests
 
 You must pass the access token in the authorization header of each API request: 
 

--- a/shared/x-topics/about-authentication.md
+++ b/shared/x-topics/about-authentication.md
@@ -12,8 +12,8 @@ When using the API Explorer in your browser, Redpanda Cloud uses the [OAuth 2.0 
 
 ## Authenticate programmatic requests
 
-For programmatic access (using a CLI, SDKs, and applications), the Cloud API uses the Client Credentials Flow as defined in [Auth 2.0 RFC 6749, section 4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4O). 
-
+For programmatic access (using a CLI, SDKs, and applications), the Cloud API uses the Client Credentials Flow as defined in [OAuth 2.0 RFC 6749, section 4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+ 
 You must first create a **service account** through which you can authenticate requests to the Cloud API. The service account is associated with your Redpanda Cloud organization. The service account acts as an OAuth 2.0 client that provides its credentials (client ID and client secret) to the API authentication server. The authentication server grants an access token in return. You can then include the access token in each request to the API.
 
 The access token granted to you is associated with a specific Redpanda Cloud organization. If you want to use the API for a different organization, you must acquire a new token through a service account with that organization.


### PR DESCRIPTION
In trying to ensure that we clearly describe how authentication works in the API Explorer, I realized that there might be too many significant changes that need to be approved and backported in the source data plane spec file. Some of the pertinent fields in the spec files that would be affected are used by tooling in console/cloudv2. To avoid breaking anything upstream, we can use overlays instead to modify the spec files to reflect the API Explorer experience.

This pull request updates documentation and API configuration to clarify authentication methods (browser vs. programmatic), improve instructions for using the API Explorer, and align API server URL handling with expected usage. The changes help users distinguish between authentication flows, correctly extract and use the Data Plane API URL, and improve compatibility with API Explorer tools.

**Authentication Documentation Improvements:**

* Rewrote `about-authentication.md` to clearly separate browser-based (API Explorer) and programmatic authentication, describing OAuth 2.0 Implicit Flow for browser use and Client Credentials Flow for scripts/SDKs. [[1]](diffhunk://#diff-0012de3944ba238ddef3aa22383a454f8f995cee5713eadd9e431fe677094b04L1-R21) [[2]](diffhunk://#diff-0012de3944ba238ddef3aa22383a454f8f995cee5713eadd9e431fe677094b04L29-R43)
* Expanded the `auth0` security scheme description to distinguish between API Explorer and programmatic authentication, with clearer instructions for each.

**API Explorer and Quickstart Guide Updates:**

* Updated quickstart guides (`quickstart.md`) for Control Plane and Data Plane APIs to clarify API Explorer usage, step-by-step resource creation, and the process of extracting and using the correct subdomain from the Data Plane API URL. [[1]](diffhunk://#diff-cfba9a7bde5d98f7a0451314f836fcd52b8427d46b7c23fd314ca62ea1e361afL27-R47) [[2]](diffhunk://#diff-cfba9a7bde5d98f7a0451314f836fcd52b8427d46b7c23fd314ca62ea1e361afL55-R86) [[3]](diffhunk://#diff-f63f374a67c9fcd0650a1e2aa6559bf7ea3ac87869b2fe50e91c12a4021cb71dL23-R34)

**API Server URL Configuration:**

* Changed the `cloud-dataplane.yaml` server URL and variables to better match how users should enter the Data Plane API subdomain, and provided a clear example in the description.
* Added an overlay (`update-dataplane-server-config.yaml`) to update the server URL template and variable description for improved API Explorer compatibility and user guidance on extracting the subdomain.