### PR TITLE
Link out to docs in main docs site

### DIFF
--- a/cloud-controlplane/cloud-controlplane.yaml
+++ b/cloud-controlplane/cloud-controlplane.yaml
@@ -4838,7 +4838,7 @@ paths:
       tags:
         - Serverless Clusters
     post:
-      description: Create a Redpanda Serverless cluster. Returns a long-running operation. See [Use the Control Plane API with Serverless](https://docs.redpanda.com/redpanda-cloud/manage/api/cloud-serverless-controlplane-api/) for more information. Call `GET /v1/operations/{id}` to check operation state.
+      description: Create a Redpanda Serverless cluster. Returns a long-running operation. For more information, see [Use the Control Plane API with Serverless](https://docs.redpanda.com/redpanda-cloud/manage/api/cloud-serverless-controlplane-api/). To check operation state, call `GET /v1/operations/{id}`.
       operationId: ServerlessClusterService_CreateServerlessCluster
       requestBody:
         content:

--- a/cloud-controlplane/cloud-controlplane.yaml
+++ b/cloud-controlplane/cloud-controlplane.yaml
@@ -4838,7 +4838,7 @@ paths:
       tags:
         - Serverless Clusters
     post:
-      description: Create a Redpanda Serverless cluster. Returns a long-running operation. See [Use the Control Plane API](https://docs.redpanda.com/redpanda-cloud/manage/api/controlplane/) for more information. Call `GET /v1/operations/{id}` to check operation state.
+      description: Create a Redpanda Serverless cluster. Returns a long-running operation. See [Use the Control Plane API with Serverless](https://docs.redpanda.com/redpanda-cloud/manage/api/cloud-serverless-controlplane-api/) for more information. Call `GET /v1/operations/{id}` to check operation state.
       operationId: ServerlessClusterService_CreateServerlessCluster
       requestBody:
         content:

--- a/cloud-controlplane/cloud-controlplane.yaml
+++ b/cloud-controlplane/cloud-controlplane.yaml
@@ -4884,7 +4884,7 @@ paths:
         - Serverless Clusters
   /v1/serverless/clusters/{id}:
     delete:
-      description: Delete Redpanda Serverless cluster. Returns a long-running operation. See [Use the Control Plane API](https://docs.redpanda.com/redpanda-cloud/manage/api/controlplane/) for more information. Call `GET /v1/operations/{id}` to check operation state.
+      description: Delete Redpanda Serverless cluster. Returns a long-running operation. For more information, see [Use the Control Plane API with Serverless](https://docs.redpanda.com/redpanda-cloud/manage/api/cloud-serverless-controlplane-api/). To check operation state, call `GET /v1/operations/{id}`.
       operationId: ServerlessClusterService_DeleteServerlessCluster
       parameters:
         - description: ID of Serverless cluster.

--- a/http-proxy/overlays/add-external-docs.yaml
+++ b/http-proxy/overlays/add-external-docs.yaml
@@ -1,0 +1,17 @@
+# Overlay to add description and external documentation links
+# to the HTTP Proxy API specification
+overlay: 1.0.0
+info:
+  title: Add External Documentation Links
+  version: 1.0.0
+actions:
+  # Add enhanced description to the info node
+  - target: "$.info"
+    update:
+      description: |
+        HTTP Proxy is an HTTP server that exposes operations you can perform directly on a Redpanda cluster. Use the Redpanda HTTP Proxy API to perform a subset of actions that are also available through the Kafka API, but using simpler REST operations.
+
+        See also: 
+
+        - [Use Redpanda Cloud with the HTTP Proxy API](https://docs.redpanda.com/redpanda-cloud/develop/http-proxy/)
+        - [Use Redpanda Self-Managed with the HTTP Proxy API](https://docs.redpanda.com/current/develop/http-proxy/)

--- a/http-proxy/overlays/add-external-docs.yaml
+++ b/http-proxy/overlays/add-external-docs.yaml
@@ -11,7 +11,8 @@ actions:
       description: |
         HTTP Proxy is an HTTP server that exposes operations you can perform directly on a Redpanda cluster. Use the Redpanda HTTP Proxy API to perform a subset of actions that are also available through the Kafka API, but using simpler REST operations.
 
-        See also: 
+        See also:
 
         - [Use Redpanda Cloud with the HTTP Proxy API](https://docs.redpanda.com/redpanda-cloud/develop/http-proxy/)
         - [Use Redpanda Self-Managed with the HTTP Proxy API](https://docs.redpanda.com/current/develop/http-proxy/)
+        

--- a/schema-registry/overlays/add-external-docs.yaml
+++ b/schema-registry/overlays/add-external-docs.yaml
@@ -11,7 +11,8 @@ actions:
       description: |
         Manage schemas within a Redpanda cluster.
 
-        See also: 
+        See also:
 
         - [Use Redpanda Cloud with the Schema Registry API](https://docs.redpanda.com/redpanda-cloud/manage/schema-reg/schema-reg-api/)
         - [Use Redpanda Self-Managed with the Schema Registry API](https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/)
+        

--- a/schema-registry/overlays/add-external-docs.yaml
+++ b/schema-registry/overlays/add-external-docs.yaml
@@ -1,0 +1,17 @@
+# Overlay to add description and external documentation links
+# to the Schema Registry API specification
+overlay: 1.0.0
+info:
+  title: Add External Documentation Links
+  version: 1.0.0
+actions:
+  # Add enhanced description to the info node
+  - target: "$.info"
+    update:
+      description: |
+        Manage schemas within a Redpanda cluster.
+
+        See also: 
+
+        - [Use Redpanda Cloud with the Schema Registry API](https://docs.redpanda.com/redpanda-cloud/manage/schema-reg/schema-reg-api/)
+        - [Use Redpanda Self-Managed with the Schema Registry API](https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/)


### PR DESCRIPTION
We have content in `docs` and `cloud-docs` that we are not migrating to `api-docs`. These are usage guides that were written to fit within the main Redpanda docs reader journey, and use Antora/AsciiDoc tools such as conditionals, single sourcing, admonitions, etc that aren't supported or don't translate 1:1 within the API reference docs and the Bump platform:

- Cloud > Use the Control Plane API (BYOC, Dedicated, and Serverless-specific docs)
- Cloud > Use the Data Plane API - keep in `cloud-docs` to maintain consistency for both APIs
- Use Redpanda with HTTP Proxy (both Cloud and Self-managed)
- Use the Schema Registry API (both Cloud and Self-managed)
- we don't currently have a usage guide for Admin API

There are cross references embedded in the Cloud API specs (primarily tag, endpoint, and property descriptions), as well as new topics (such as the [Data Plane quickstart](https://deploy-preview-113--redpanda-documentation.netlify.app/api/doc/cloud-dataplane/topic/topic-quickstart)) that link back out to the relevant RP Cloud docs, but we have not done the same for the other APIs.

This pull request enhances API documentation by updating descriptions and adding external documentation links for the HTTP Proxy and Schema Registry APIs, and by updating a reference in the Serverless Clusters API documentation. These changes improve clarity and provide direct access to relevant guides for users.

Note: We can add more comprehensive descriptions and links out in various places in the different API specs in the future. We should map out the reader journeys inclusive of the new API docs and API Explorer to decide the best way to present the relevant docs to our readers when and where they need them most. This PR just provides a foundation that ensures we have at least some linking across the main docs and all API docs.

**API Documentation Improvements:**

* Added an overlay file to the HTTP Proxy API (`http-proxy/overlays/add-external-docs.yaml`) that provides an enhanced description and includes links to both Redpanda Cloud and Self-Managed HTTP Proxy API documentation.
* Added an overlay file to the Schema Registry API (`schema-registry/overlays/add-external-docs.yaml`) that provides an improved description and links to Redpanda Cloud and Self-Managed Schema Registry API documentation.

**Reference Update:**

* Updated the description for creating a Serverless Cluster in `cloud-controlplane/cloud-controlplane.yaml` to point to the correct Serverless Control Plane API documentation link.