### PR TITLE
Catch up to latest spec versions from docs/api branch

### DIFF
--- a/schema-registry/schema-registry.json
+++ b/schema-registry/schema-registry.json
@@ -2,9 +2,9 @@
   "swagger": "2.0",
   "info": {
     "title": "Redpanda Schema Registry API",
-    "version": "1.0.6"
+    "version": "1.1.0"
   },
-  "host": "localhost:18081",
+  "host": "localhost:8081",
   "basePath": "/",
   "schemes": [
     "http"
@@ -41,7 +41,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -84,7 +84,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -115,13 +115,13 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -147,7 +147,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -184,7 +184,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -210,7 +210,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -253,7 +253,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -300,7 +300,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -356,7 +356,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -394,7 +394,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -423,7 +423,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -441,6 +441,13 @@
             "in": "path",
             "required": true,
             "type": "integer"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -464,13 +471,19 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -514,13 +527,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -562,13 +575,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -585,7 +598,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "subjectPrefix",
@@ -647,6 +660,13 @@
             "type": "boolean"
           },
           {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
+          },
+          {
             "name": "schema_def",
             "in": "body",
             "schema": {
@@ -663,11 +683,11 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
-            "description": "Not found",
+            "description": "Not Found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -686,6 +706,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -725,7 +751,7 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -754,7 +780,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           }
         ],
         "produces": [
@@ -773,7 +799,7 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -874,7 +900,14 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -886,11 +919,11 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -903,6 +936,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -945,7 +984,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -967,8 +1006,9 @@
     },
     "/subjects/{subject}/versions/{version}/schema": {
       "get": {
-        "summary": "Retrieve a schema for the subject and version.",
+        "summary": "Retrieve the raw schema for the subject.",
         "operationId": "get_subject_versions_version_schema",
+        "description": "Returns the specified version of the schema in its original format, without backslashes.",
         "parameters": [
           {
             "name": "subject",
@@ -986,7 +1026,14 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -1002,7 +1049,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1015,6 +1062,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1056,7 +1109,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1111,7 +1164,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1214,8 +1267,218 @@
           }
         }
       }
+    },
+    "/security/acls": {
+      "get": {
+        "summary": "List ACLs",
+        "description": "Returns a list of ACL rules that match the specified filters.",
+        "operationId": "get_security_acls",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "principal",
+            "in": "query",
+            "type": "string",
+            "description": "The name of the principal, for example, User:alice or RedpandaRole:admin. Use \"*\" to represent a wildcard."
+          },
+          {
+            "name": "resource",
+            "in": "query",
+            "type": "string",
+            "description": "The name of the resource. Use \"*\" to represent a wildcard."
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["REGISTRY", "SUBJECT"],
+            "description": "The type of resource being secured. The REGISTRY type maps to top-level operations such as `GET /mode` and `GET /config`. The SUBJECT type maps to operations on the subject level, such as `GET /subjects` and `GET /config/{subject}`."
+          },
+          {
+            "name": "pattern_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["LITERAL", "PREFIXED"],
+            "description": "Pattern match type for the resource. Only applies when `resource_type` is SUBJECT."
+          },
+          {
+            "name": "host",
+            "in": "query",
+            "type": "string",
+            "description": "Originating host for which this rule applies. Use \"*\" to represent a wildcard."
+          },
+          {
+            "name": "operation",
+            "in": "query",
+            "type": "string",
+            "enum": ["ALL", "READ", "WRITE", "DELETE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER_CONFIGS"],
+            "description": "The operation to allow or deny."
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "type": "string",
+            "enum": ["ALLOW", "DENY"],
+            "description": "Specifies whether the operation is allowed or denied."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List ACLs",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "principal": "User:alice",
+                  "resource": "model-",
+                  "resource_type": "SUBJECT",
+                  "pattern_type": "PREFIXED",
+                  "operation": "READ",
+                  "permission": "ALLOW",
+                  "host": "*"
+                }
+              ]
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create ACLs",
+        "description": "Create new ACL rules.",
+        "operationId": "post_security_acls",
+        "parameters": [
+          {
+            "name": "acls",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "ACLs created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete ACLs",
+        "description": "Delete ACL rules that match the specified definitions exactly.",
+        "operationId": "delete_security_acls",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "acls",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ACLs deleted",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
     }
-  },"definitions": {
+  },
+  "definitions": {
     "error_body": {
       "type": "object",
       "properties": {
@@ -1255,7 +1518,7 @@
         }
       }
     },
-    "subject_schema": {
+    "stored_schema": {
       "type": "object",
       "properties": {
         "subject": {
@@ -1333,5 +1596,69 @@
           }
         }
       }
+    },
+    "security_acl": {
+      "type": "object",
+      "required": [
+        "principal",
+        "resource",
+        "resource_type",
+        "pattern_type",
+        "host",
+        "operation",
+        "permission"
+      ],
+      "properties": {
+        "principal": {
+          "type": "string",
+          "description": "The name of the principal, for example, User:alice or RedpandaRole:admin. Use \"*\" to represent a wildcard."
+        },
+        "resource": {
+          "type": "string",
+          "description": "The name of the resource. Use \"*\" to represent a wildcard."
+        },
+        "resource_type": {
+          "type": "string",
+          "enum": [
+            "REGISTRY",
+            "SUBJECT"
+          ],
+          "description": "The type of resource being secured."
+        },
+        "pattern_type": {
+          "type": "string",
+          "enum": [
+            "LITERAL",
+            "PREFIXED"
+          ],
+          "description": "Pattern match type for the resource. Only applies when `resource_type` is SUBJECT."
+        },
+        "host": {
+          "type": "string",
+          "description": "Originating host for which this rule applies. Use \"*\" to represent a wildcard."
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "ALL",
+            "READ",
+            "WRITE",
+            "DELETE",
+            "DESCRIBE",
+            "DESCRIBE_CONFIGS",
+            "ALTER_CONFIGS"
+          ],
+          "description": "The operation to allow or deny."
+        },
+        "permission": {
+          "type": "string",
+          "enum": [
+            "ALLOW",
+            "DENY"
+          ],
+          "description": "Specifies whether the operation is allowed or denied."
+        }
+      }
     }
-}}
+  }
+}


### PR DESCRIPTION
This PR ensures that this repo has the latest version of the API spec files from https://github.com/redpanda-data/docs/tree/api/modules/ROOT/attachments (Cloud APIs are handled by GH automation).