### PR TITLE
[26.1] Security v2

### DIFF
--- a/admin/admin-v2.yaml
+++ b/admin/admin-v2.yaml
@@ -2430,9 +2430,9 @@ components:
 info:
   description: Redpanda Admin API specification
   title: Redpanda Admin API
-  version: "26.1"
+  version: v2.0.0
   x-admin-api-major: v2.0.0
-  x-generated-at: 2026-03-14T00:12:06.766Z
+  x-generated-at: 2026-03-18T00:41:12.496Z
   x-generator: redpanda-docs-openapi-bundler
   x-redpanda-core-version: v26.1.1-rc2
 openapi: 3.1.0

--- a/admin/admin-v2.yaml
+++ b/admin/admin-v2.yaml
@@ -441,11 +441,13 @@ components:
           title: host
           type: string
         operation:
-          $ref: "#/components/schemas/redpanda.core.common.v1.ACLOperation"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.common.v1.ACLOperation"
           description: The ACL operation to match
           title: operation
         permissionType:
-          $ref: "#/components/schemas/redpanda.core.common.v1.ACLPermissionType"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.common.v1.ACLPermissionType"
           description: The permission type
           title: permission_type
         principal:
@@ -461,11 +463,13 @@ components:
       description: A filter for ACLs
       properties:
         accessFilter:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ACLAccessFilter"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ACLAccessFilter"
           description: The access filter
           title: access_filter
         resourceFilter:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ACLResourceFilter"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ACLResourceFilter"
           description: The resource filter
           title: resource_filter
       title: ACLFilter
@@ -482,11 +486,13 @@ components:
           title: name
           type: string
         patternType:
-          $ref: "#/components/schemas/redpanda.core.common.v1.ACLPattern"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.common.v1.ACLPattern"
           description: The pattern to apply to name
           title: pattern_type
         resourceType:
-          $ref: "#/components/schemas/redpanda.core.common.v1.ACLResource"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.common.v1.ACLResource"
           description: The ACL resource type to match
           title: resource_type
       title: ACLResourceFilter
@@ -517,7 +523,8 @@ components:
       description: AddRoleMembersResponse is the response from the AddRoleMembers RPC.
       properties:
         role:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
           description: The updated Role.
           title: role
       title: AddRoleMembersResponse
@@ -543,7 +550,8 @@ components:
       oneOf:
         - properties:
             plainConfiguration:
-              $ref: "#/components/schemas/redpanda.core.admin.v2.PlainConfig"
+              allOf:
+                - $ref: "#/components/schemas/redpanda.core.admin.v2.PlainConfig"
               description: SASL/PLAIN configuration
               title: plain_configuration
           required:
@@ -551,7 +559,8 @@ components:
           title: plain_configuration
         - properties:
             scramConfiguration:
-              $ref: "#/components/schemas/redpanda.core.admin.v2.ScramConfig"
+              allOf:
+                - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramConfig"
               description: SASL/SCRAM configuration
               title: scram_configuration
           required:
@@ -564,11 +573,13 @@ components:
       description: Other Messages
       properties:
         mechanism:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationMechanism"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationMechanism"
           description: Authentication mechanism
           title: mechanism
         state:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationState"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationState"
           description: Authentication state
           title: state
         userPrincipal:
@@ -600,7 +611,8 @@ components:
       description: The resource for an individual broker within the Kafka Cluster.
       properties:
         adminServer:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.AdminServer"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.AdminServer"
           description: |-
             The admin server information.
 
@@ -608,7 +620,8 @@ components:
           nullable: true
           title: admin_server
         buildInfo:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.BuildInfo"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.BuildInfo"
           description: |-
             The build this broker is running.
 
@@ -641,7 +654,8 @@ components:
       description: Options for syncing consumer offsets
       properties:
         effectiveInterval:
-          $ref: "#/components/schemas/google.protobuf.Duration"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Duration"
           description: The effective interval for the task
           readOnly: true
           title: effective_interval
@@ -652,7 +666,8 @@ components:
           title: group_filters
           type: array
         interval:
-          $ref: "#/components/schemas/google.protobuf.Duration"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Duration"
           description: |-
             Sync interval
              If 0 provided, defaults to 30 seconds
@@ -671,7 +686,8 @@ components:
       description: CreateRoleRequest is the request for the CreateRole RPC.
       properties:
         role:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
           description: The Role to create.
           title: role
       required:
@@ -683,7 +699,8 @@ components:
       description: CreateRoleResponse is the response from the CreateRole RPC.
       properties:
         role:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
           description: The created Role.
           title: role
       title: CreateRoleResponse
@@ -695,7 +712,8 @@ components:
          RPC.
       properties:
         scramCredential:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
           description: The SCRAM credential to create.
           title: scram_credential
       required:
@@ -709,7 +727,8 @@ components:
          RPC.
       properties:
         scramCredential:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
           description: The created SCRAM credential.
           title: scram_credential
       title: CreateScramCredentialResponse
@@ -719,7 +738,8 @@ components:
       description: Create a new shadow link
       properties:
         shadowLink:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
           description: The shadow link to create
           title: shadow_link
       title: CreateShadowLinkRequest
@@ -729,7 +749,8 @@ components:
       description: Response to creating a shadow link
       properties:
         shadowLink:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
           description: The shadow link that was created
           title: shadow_link
       title: CreateShadowLinkResponse
@@ -823,7 +844,8 @@ components:
       description: The response to the FailOverRequest
       properties:
         shadowLink:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
           description: The shadow link that was failed over
           title: shadow_link
       title: FailOverResponse
@@ -855,7 +877,8 @@ components:
       description: GetBrokerResponse is the response from the GetBroker RPC.
       properties:
         broker:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Broker"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Broker"
           description: The specified broker and it's information.
           title: broker
       title: GetBrokerResponse
@@ -877,7 +900,8 @@ components:
       description: GetRoleResponse is the response from the GetRole RPC.
       properties:
         role:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
           description: The requested Role.
           title: role
       title: GetRoleResponse
@@ -899,7 +923,8 @@ components:
       description: GetScramCredentialResponse is the response from the GetScramCredential RPC.
       properties:
         scramCredential:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
           description: The requested SCRAM credential.
           title: scram_credential
       title: GetScramCredentialResponse
@@ -921,7 +946,8 @@ components:
       description: Response to getting a shadow link
       properties:
         shadowLink:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
           description: The shadow link that was retrieved
           title: shadow_link
       title: GetShadowLinkResponse
@@ -948,7 +974,8 @@ components:
       description: Response of to getting a shadow topic
       properties:
         shadowTopic:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowTopic"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowTopic"
           title: shadow_topic
       title: GetShadowTopicResponse
       type: object
@@ -980,7 +1007,8 @@ components:
           title: api_key
           type: integer
         inFlightDuration:
-          $ref: "#/components/schemas/google.protobuf.Duration"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Duration"
           description: How long the request has been in-flight since it was received
           title: in_flight_duration
       title: Request
@@ -1012,7 +1040,8 @@ components:
           title: api_versions
           type: object
         authenticationInfo:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationInfo"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationInfo"
           description: Information about the authentication state of the connection
           title: authentication_info
         clientId:
@@ -1038,7 +1067,8 @@ components:
           title: client_software_version
           type: string
         closeTime:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: |-
             When the connection was closed. This field is set only when the
              connection state is "closed".
@@ -1066,11 +1096,13 @@ components:
           title: group_member_id
           type: string
         idleDuration:
-          $ref: "#/components/schemas/google.protobuf.Duration"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Duration"
           description: How long the connection has been idle (no in-flight requests)
           title: idle_duration
         inFlightRequests:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.InFlightRequests"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.InFlightRequests"
           description: Currently in-flight requests
           title: in_flight_requests
         listenerName:
@@ -1087,11 +1119,13 @@ components:
           title: node_id
           type: integer
         openTime:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: When the broker accepted the connection
           title: open_time
         recentRequestStatistics:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.RequestStatistics"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.RequestStatistics"
           description: Statistics for previous last one minute window.
           title: recent_request_statistics
         shardId:
@@ -1099,21 +1133,25 @@ components:
           title: shard_id
           type: integer
         source:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Source"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Source"
           description: Remote client address of the TCP connection
           title: source
         state:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.KafkaConnectionState"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.KafkaConnectionState"
           description: Lifecycle state of the connection (open/aborting/closed)
           title: state
         tlsInfo:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.TLSInfo"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.TLSInfo"
           description: |-
             Information about the TLS state of the connection (e.g., whether TLS
              encryption is used for this connection)
           title: tls_info
         totalRequestStatistics:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.RequestStatistics"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.RequestStatistics"
           description: Aggregated statistics for the entire connection's lifetime.
           title: total_request_statistics
         transactionalId:
@@ -1366,7 +1404,8 @@ components:
       description: A filter based on the name of a resource
       properties:
         filterType:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.FilterType"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.FilterType"
           description: Include or exclude
           title: filter_type
         name:
@@ -1377,7 +1416,8 @@ components:
           title: name
           type: string
         patternType:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.PatternType"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.PatternType"
           description: Literal or prefix
           title: pattern_type
       title: NameFilter
@@ -1406,7 +1446,8 @@ components:
           title: password_set
           type: boolean
         passwordSetAt:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: |-
             Timestamp of when the password was last set - only valid if password_set
              is true
@@ -1474,7 +1515,8 @@ components:
       description: RemoveRoleMembersResponse is the response from the RemoveRoleMembers RPC.
       properties:
         role:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
           description: The updated Role.
           title: role
       title: RemoveRoleMembersResponse
@@ -1524,7 +1566,8 @@ components:
       description: ResolveOidcIdentityResponse is the response from the ResolveOidcIdentity RPC.
       properties:
         expire:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: The timestamp of the token's expiry.
           title: expire
         groups:
@@ -1583,14 +1626,16 @@ components:
       oneOf:
         - properties:
             group:
-              $ref: "#/components/schemas/redpanda.core.admin.v2.RoleGroup"
+              allOf:
+                - $ref: "#/components/schemas/redpanda.core.admin.v2.RoleGroup"
               title: group
           required:
             - group
           title: group
         - properties:
             user:
-              $ref: "#/components/schemas/redpanda.core.admin.v2.RoleUser"
+              allOf:
+                - $ref: "#/components/schemas/redpanda.core.admin.v2.RoleUser"
               title: user
           required:
             - user
@@ -1613,7 +1658,8 @@ components:
       oneOf:
         - properties:
             shadowSchemaRegistryTopic:
-              $ref: "#/components/schemas/redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryTopic"
+              allOf:
+                - $ref: "#/components/schemas/redpanda.core.admin.v2.SchemaRegistrySyncOptions.ShadowSchemaRegistryTopic"
               title: shadow_schema_registry_topic
           required:
             - shadowSchemaRegistryTopic
@@ -1653,14 +1699,16 @@ components:
           title: password_set
           type: boolean
         passwordSetAt:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: |-
             Timestamp of when the password was last set - only valid if password_set
              is true
           readOnly: true
           title: password_set_at
         scramMechanism:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramMechanism"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramMechanism"
           description: The SCRAM mechanism to use
           title: scram_mechanism
         username:
@@ -1674,7 +1722,8 @@ components:
       description: The ScramCredential resource used for SCRAM authentication.
       properties:
         mechanism:
-          $ref: "#/components/schemas/redpanda.core.common.v1.ScramMechanism"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.common.v1.ScramMechanism"
           description: The SCRAM mechanism used for this credential.
           title: mechanism
         name:
@@ -1687,7 +1736,8 @@ components:
           type: string
           writeOnly: true
         passwordSetAt:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: |-
             The timestamp when the password was last set.
              For passwords set before this feature was implemented, this will return
@@ -1717,12 +1767,14 @@ components:
           title: acl_filters
           type: array
         effectiveInterval:
-          $ref: "#/components/schemas/google.protobuf.Duration"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Duration"
           description: The effective interval for the task
           readOnly: true
           title: effective_interval
         interval:
-          $ref: "#/components/schemas/google.protobuf.Duration"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Duration"
           description: |-
             Sync interval
              If 0 provided, defaults to 30 seconds
@@ -1741,7 +1793,8 @@ components:
       description: A ShadowLink resource
       properties:
         configurations:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkConfigurations"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkConfigurations"
           description: Shadow link configuration
           title: configurations
         name:
@@ -1749,7 +1802,8 @@ components:
           title: name
           type: string
         status:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkStatus"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkStatus"
           description: Status of the shadow link
           readOnly: true
           title: status
@@ -1767,7 +1821,8 @@ components:
       description: Options for the client link
       properties:
         authenticationConfiguration:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationConfiguration"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.AuthenticationConfiguration"
           description: Authentication settings
           nullable: true
           title: authentication_configuration
@@ -1884,7 +1939,8 @@ components:
           title: source_cluster_id
           type: string
         tlsSettings:
-          $ref: "#/components/schemas/redpanda.core.common.v1.TLSSettings"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.common.v1.TLSSettings"
           description: TLS settings
           nullable: true
           title: tls_settings
@@ -1897,23 +1953,28 @@ components:
       description: ShadowLink options
       properties:
         clientOptions:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkClientOptions"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkClientOptions"
           description: Configuration for the internal kafka client
           title: client_options
         consumerOffsetSyncOptions:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ConsumerOffsetSyncOptions"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ConsumerOffsetSyncOptions"
           description: Consumer offset sync options
           title: consumer_offset_sync_options
         schemaRegistrySyncOptions:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.SchemaRegistrySyncOptions"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.SchemaRegistrySyncOptions"
           description: Schema Registry sync options
           title: schema_registry_sync_options
         securitySyncOptions:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.SecuritySettingsSyncOptions"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.SecuritySettingsSyncOptions"
           description: Security settings sync options
           title: security_sync_options
         topicMetadataSyncOptions:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.TopicMetadataSyncOptions"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.TopicMetadataSyncOptions"
           description: Topic metadata sync options
           title: topic_metadata_sync_options
       title: ShadowLinkConfigurations
@@ -1937,7 +1998,8 @@ components:
           title: shadow_topics
           type: array
         state:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkState"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLinkState"
           title: state
         syncedShadowTopicProperties:
           description: List of topic properties that are being synced
@@ -1976,7 +2038,8 @@ components:
           title: shard
           type: integer
         state:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.TaskState"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.TaskState"
           description: State of the task
           title: state
       title: ShadowLinkTaskStatus
@@ -2000,7 +2063,8 @@ components:
           title: source_topic_name
           type: string
         status:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowTopicStatus"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowTopicStatus"
           description: The status of the shadow topic
           readOnly: true
           title: status
@@ -2035,7 +2099,8 @@ components:
           title: partition_information
           type: array
         state:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowTopicState"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowTopicState"
           description: State of the shadow topic
           title: state
       title: ShadowTopicStatus
@@ -2093,7 +2158,8 @@ components:
               title: auto_create_shadow_topic_filters
               type: array
             effectiveInterval:
-              $ref: "#/components/schemas/google.protobuf.Duration"
+              allOf:
+                - $ref: "#/components/schemas/google.protobuf.Duration"
               description: The effective interval for the task
               readOnly: true
               title: effective_interval
@@ -2113,7 +2179,8 @@ components:
               title: exclude_default
               type: boolean
             interval:
-              $ref: "#/components/schemas/google.protobuf.Duration"
+              allOf:
+                - $ref: "#/components/schemas/google.protobuf.Duration"
               description: |-
                 How often to sync metadata
                  If 0 provided, defaults to 30 seconds
@@ -2152,7 +2219,8 @@ components:
         - oneOf:
             - properties:
                 startAtEarliest:
-                  $ref: "#/components/schemas/redpanda.core.admin.v2.TopicMetadataSyncOptions.EarliestOffset"
+                  allOf:
+                    - $ref: "#/components/schemas/redpanda.core.admin.v2.TopicMetadataSyncOptions.EarliestOffset"
                   description: |-
                     Enables data replication from the earliest offset
                      on the source topic/partition.
@@ -2162,7 +2230,8 @@ components:
               title: start_at_earliest
             - properties:
                 startAtLatest:
-                  $ref: "#/components/schemas/redpanda.core.admin.v2.TopicMetadataSyncOptions.LatestOffset"
+                  allOf:
+                    - $ref: "#/components/schemas/redpanda.core.admin.v2.TopicMetadataSyncOptions.LatestOffset"
                   description: |-
                     Enables data replication from the latest offset
                      on the source topic/partition.
@@ -2172,7 +2241,8 @@ components:
               title: start_at_latest
             - properties:
                 startAtTimestamp:
-                  $ref: "#/components/schemas/google.protobuf.Timestamp"
+                  allOf:
+                    - $ref: "#/components/schemas/google.protobuf.Timestamp"
                   description: |-
                     Enables data replication from the first offset on the
                      source topic/partition where the record's timestamp is
@@ -2227,7 +2297,8 @@ components:
             - integer
             - string
         sourceLastUpdatedTimestamp:
-          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.Timestamp"
           description: Timestamp of the last time the source partition information was updated
           title: source_last_updated_timestamp
       title: TopicPartitionInformation
@@ -2239,11 +2310,13 @@ components:
          RPC.
       properties:
         scramCredential:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
           description: The SCRAM credential to update.
           title: scram_credential
         updateMask:
-          $ref: "#/components/schemas/google.protobuf.FieldMask"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.FieldMask"
           description: |-
             The list of fields to update
              See [AIP-134](https://google.aip.dev/134) for how to use `field_mask`
@@ -2259,7 +2332,8 @@ components:
          RPC.
       properties:
         scramCredential:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
           description: The updated SCRAM credential.
           title: scram_credential
       title: UpdateScramCredentialResponse
@@ -2269,11 +2343,13 @@ components:
       description: Updates a shadow link
       properties:
         shadowLink:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
           description: The shadow link to update
           title: shadow_link
         updateMask:
-          $ref: "#/components/schemas/google.protobuf.FieldMask"
+          allOf:
+            - $ref: "#/components/schemas/google.protobuf.FieldMask"
           description: |-
             The list of fields to update
              See [AIP-134](https://google.aip.dev/134) for how to use `field_mask`
@@ -2285,7 +2361,8 @@ components:
       description: Response to the update shadow link request
       properties:
         shadowLink:
-          $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
+          allOf:
+            - $ref: "#/components/schemas/redpanda.core.admin.v2.ShadowLink"
           description: The shadow link that was updated
           title: shadow_link
       title: UpdateShadowLinkResponse
@@ -2410,7 +2487,8 @@ components:
         - oneOf:
             - properties:
                 tlsFileSettings:
-                  $ref: "#/components/schemas/redpanda.core.common.v1.TLSFileSettings"
+                  allOf:
+                    - $ref: "#/components/schemas/redpanda.core.common.v1.TLSFileSettings"
                   description: Certificates and keys are provided as files
                   title: tls_file_settings
               required:
@@ -2418,7 +2496,8 @@ components:
               title: tls_file_settings
             - properties:
                 tlsPemSettings:
-                  $ref: "#/components/schemas/redpanda.core.common.v1.TLSPEMSettings"
+                  allOf:
+                    - $ref: "#/components/schemas/redpanda.core.common.v1.TLSPEMSettings"
                   description: Certificates and keys are provided in PEM format
                   title: tls_pem_settings
               required:
@@ -2432,7 +2511,7 @@ info:
   title: Redpanda Admin API
   version: v2.0.0
   x-admin-api-major: v2.0.0
-  x-generated-at: 2026-03-18T00:41:12.496Z
+  x-generated-at: 2026-03-19T03:09:31.752Z
   x-generator: redpanda-docs-openapi-bundler
   x-redpanda-core-version: v26.1.1-rc2
 openapi: 3.1.0

--- a/admin/admin-v2.yaml
+++ b/admin/admin-v2.yaml
@@ -491,6 +491,37 @@ components:
           title: resource_type
       title: ACLResourceFilter
       type: object
+    redpanda.core.admin.v2.AddRoleMembersRequest:
+      additionalProperties: false
+      description: AddRoleMembersRequest is the request for the AddRoleMembers RPC.
+      properties:
+        members:
+          description: |-
+            The members to add to the Role. If any members are already part of the
+             role, they are ignored.
+          items:
+            $ref: "#/components/schemas/redpanda.core.admin.v2.RoleMember"
+          title: members
+          type: array
+        roleName:
+          description: The name of the Role to add members to.
+          title: role_name
+          type: string
+      required:
+        - roleName
+        - members
+      title: AddRoleMembersRequest
+      type: object
+    redpanda.core.admin.v2.AddRoleMembersResponse:
+      additionalProperties: false
+      description: AddRoleMembersResponse is the response from the AddRoleMembers RPC.
+      properties:
+        role:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          description: The updated Role.
+          title: role
+      title: AddRoleMembersResponse
+      type: object
     redpanda.core.admin.v2.AdminServer:
       additionalProperties: false
       description: AdminServer has information about the admin server within the broker.
@@ -570,11 +601,19 @@ components:
       properties:
         adminServer:
           $ref: "#/components/schemas/redpanda.core.admin.v2.AdminServer"
-          description: The admin server information.
+          description: |-
+            The admin server information.
+
+             Only populated for `GetBroker` RPCs
+          nullable: true
           title: admin_server
         buildInfo:
           $ref: "#/components/schemas/redpanda.core.admin.v2.BuildInfo"
-          description: The build this broker is running.
+          description: |-
+            The build this broker is running.
+
+             Only populated for `GetBroker` RPCs
+          nullable: true
           title: build_info
         nodeId:
           description: This broker's node ID.
@@ -627,6 +666,54 @@ components:
           type: boolean
       title: ConsumerOffsetSyncOptions
       type: object
+    redpanda.core.admin.v2.CreateRoleRequest:
+      additionalProperties: false
+      description: CreateRoleRequest is the request for the CreateRole RPC.
+      properties:
+        role:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          description: The Role to create.
+          title: role
+      required:
+        - role
+      title: CreateRoleRequest
+      type: object
+    redpanda.core.admin.v2.CreateRoleResponse:
+      additionalProperties: false
+      description: CreateRoleResponse is the response from the CreateRole RPC.
+      properties:
+        role:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          description: The created Role.
+          title: role
+      title: CreateRoleResponse
+      type: object
+    redpanda.core.admin.v2.CreateScramCredentialRequest:
+      additionalProperties: false
+      description: |-
+        CreateScramCredentialRequest is the request for the CreateScramCredential
+         RPC.
+      properties:
+        scramCredential:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          description: The SCRAM credential to create.
+          title: scram_credential
+      required:
+        - scramCredential
+      title: CreateScramCredentialRequest
+      type: object
+    redpanda.core.admin.v2.CreateScramCredentialResponse:
+      additionalProperties: false
+      description: |-
+        CreateScramCredentialResponse is the response from the CreateScramCredential
+         RPC.
+      properties:
+        scramCredential:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          description: The created SCRAM credential.
+          title: scram_credential
+      title: CreateScramCredentialResponse
+      type: object
     redpanda.core.admin.v2.CreateShadowLinkRequest:
       additionalProperties: false
       description: Create a new shadow link
@@ -646,6 +733,48 @@ components:
           description: The shadow link that was created
           title: shadow_link
       title: CreateShadowLinkResponse
+      type: object
+    redpanda.core.admin.v2.DeleteRoleRequest:
+      additionalProperties: false
+      description: DeleteRoleRequest is the request for the DeleteRole RPC.
+      properties:
+        deleteAcls:
+          description: Whether to also delete any ACLs associated with this role.
+          title: delete_acls
+          type: boolean
+        name:
+          description: The name of the Role to delete.
+          title: name
+          type: string
+      required:
+        - name
+      title: DeleteRoleRequest
+      type: object
+    redpanda.core.admin.v2.DeleteRoleResponse:
+      additionalProperties: false
+      description: DeleteRoleResponse is the response from the DeleteRole RPC.
+      title: DeleteRoleResponse
+      type: object
+    redpanda.core.admin.v2.DeleteScramCredentialRequest:
+      additionalProperties: false
+      description: |-
+        DeleteScramCredentialRequest is the request for the DeleteScramCredential
+         RPC.
+      properties:
+        name:
+          description: The name of the SCRAM credential to delete.
+          title: name
+          type: string
+      required:
+        - name
+      title: DeleteScramCredentialRequest
+      type: object
+    redpanda.core.admin.v2.DeleteScramCredentialResponse:
+      additionalProperties: false
+      description: |-
+        DeleteScramCredentialResponse is the response from the DeleteScramCredential
+         RPC.
+      title: DeleteScramCredentialResponse
       type: object
     redpanda.core.admin.v2.DeleteShadowLinkRequest:
       additionalProperties: false
@@ -713,9 +842,10 @@ components:
       properties:
         nodeId:
           description: |-
-            The node ID for the broker. If set to -1, the broker handling the RPC
+            The node ID for the broker. If unset, the broker handling the RPC
              request returns information about itself.
           format: int32
+          nullable: true
           title: node_id
           type: integer
       title: GetBrokerRequest
@@ -729,6 +859,50 @@ components:
           description: The specified broker and it's information.
           title: broker
       title: GetBrokerResponse
+      type: object
+    redpanda.core.admin.v2.GetRoleRequest:
+      additionalProperties: false
+      description: GetRoleRequest is the request for the GetRole RPC.
+      properties:
+        name:
+          description: The name of the Role to retrieve.
+          title: name
+          type: string
+      required:
+        - name
+      title: GetRoleRequest
+      type: object
+    redpanda.core.admin.v2.GetRoleResponse:
+      additionalProperties: false
+      description: GetRoleResponse is the response from the GetRole RPC.
+      properties:
+        role:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          description: The requested Role.
+          title: role
+      title: GetRoleResponse
+      type: object
+    redpanda.core.admin.v2.GetScramCredentialRequest:
+      additionalProperties: false
+      description: GetScramCredentialRequest is the request for the GetScramCredential RPC.
+      properties:
+        name:
+          description: The name of the SCRAM credential to retrieve.
+          title: name
+          type: string
+      required:
+        - name
+      title: GetScramCredentialRequest
+      type: object
+    redpanda.core.admin.v2.GetScramCredentialResponse:
+      additionalProperties: false
+      description: GetScramCredentialResponse is the response from the GetScramCredential RPC.
+      properties:
+        scramCredential:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          description: The requested SCRAM credential.
+          title: scram_credential
+      title: GetScramCredentialResponse
       type: object
     redpanda.core.admin.v2.GetShadowLinkRequest:
       additionalProperties: false
@@ -991,6 +1165,29 @@ components:
           type: array
       title: ListBrokersResponse
       type: object
+    redpanda.core.admin.v2.ListCurrentUserRolesRequest:
+      additionalProperties: false
+      description: ListCurrentUserRolesRequest is the request for the ListCurrentUserRoles RPC.
+      title: ListCurrentUserRolesRequest
+      type: object
+    redpanda.core.admin.v2.ListCurrentUserRolesResponse:
+      additionalProperties: false
+      description: |-
+        ListCurrentUserRolesResponse is the response from the ListCurrentUserRoles
+         RPC.
+      properties:
+        roles:
+          description: |-
+            The list of Role names that the current authenticated user is a member
+             of.
+          items:
+            readOnly: true
+            type: string
+          readOnly: true
+          title: roles
+          type: array
+      title: ListCurrentUserRolesResponse
+      type: object
     redpanda.core.admin.v2.ListKafkaConnectionsRequest:
       additionalProperties: false
       description: |-
@@ -1088,6 +1285,42 @@ components:
             - integer
             - string
       title: ListKafkaConnectionsResponse
+      type: object
+    redpanda.core.admin.v2.ListRolesRequest:
+      additionalProperties: false
+      description: ListRolesRequest is the request for the ListRoles RPC.
+      title: ListRolesRequest
+      type: object
+    redpanda.core.admin.v2.ListRolesResponse:
+      additionalProperties: false
+      description: ListRolesResponse is the response from the ListRoles RPC.
+      properties:
+        roles:
+          description: The list of Roles.
+          items:
+            $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          title: roles
+          type: array
+      title: ListRolesResponse
+      type: object
+    redpanda.core.admin.v2.ListScramCredentialsRequest:
+      additionalProperties: false
+      description: ListScramCredentialsRequest is the request for the ListScramCredentials RPC.
+      title: ListScramCredentialsRequest
+      type: object
+    redpanda.core.admin.v2.ListScramCredentialsResponse:
+      additionalProperties: false
+      description: |-
+        ListScramCredentialsResponse is the response from the ListScramCredentials
+         RPC.
+      properties:
+        scramCredentials:
+          description: The list of SCRAM credentials.
+          items:
+            $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          title: scram_credentials
+          type: array
+      title: ListScramCredentialsResponse
       type: object
     redpanda.core.admin.v2.ListShadowLinksRequest:
       additionalProperties: false
@@ -1205,6 +1438,47 @@ components:
           type: string
       title: RPCRoute
       type: object
+    redpanda.core.admin.v2.RefreshOidcKeysRequest:
+      additionalProperties: false
+      description: RefreshOidcKeysRequest is the request for the RefreshOidcKeys RPC.
+      title: RefreshOidcKeysRequest
+      type: object
+    redpanda.core.admin.v2.RefreshOidcKeysResponse:
+      additionalProperties: false
+      description: RefreshOidcKeysResponse is the response from the RefreshOidcKeys RPC.
+      title: RefreshOidcKeysResponse
+      type: object
+    redpanda.core.admin.v2.RemoveRoleMembersRequest:
+      additionalProperties: false
+      description: RemoveRoleMembersRequest is the request for the RemoveRoleMembers RPC.
+      properties:
+        members:
+          description: |-
+            The members to remove from the Role. If any members are already not part
+             of the role, they are ignored.
+          items:
+            $ref: "#/components/schemas/redpanda.core.admin.v2.RoleMember"
+          title: members
+          type: array
+        roleName:
+          description: The name of the Role to remove members from.
+          title: role_name
+          type: string
+      required:
+        - roleName
+        - members
+      title: RemoveRoleMembersRequest
+      type: object
+    redpanda.core.admin.v2.RemoveRoleMembersResponse:
+      additionalProperties: false
+      description: RemoveRoleMembersResponse is the response from the RemoveRoleMembers RPC.
+      properties:
+        role:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.Role"
+          description: The updated Role.
+          title: role
+      title: RemoveRoleMembersResponse
+      type: object
     redpanda.core.admin.v2.RequestStatistics:
       additionalProperties: false
       properties:
@@ -1239,6 +1513,99 @@ components:
             - integer
             - string
       title: RequestStatistics
+      type: object
+    redpanda.core.admin.v2.ResolveOidcIdentityRequest:
+      additionalProperties: false
+      description: ResolveOidcIdentityRequest is the request for the ResolveOidcIdentity RPC.
+      title: ResolveOidcIdentityRequest
+      type: object
+    redpanda.core.admin.v2.ResolveOidcIdentityResponse:
+      additionalProperties: false
+      description: ResolveOidcIdentityResponse is the response from the ResolveOidcIdentity RPC.
+      properties:
+        expire:
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          description: The timestamp of the token's expiry.
+          title: expire
+        groups:
+          description: The groups resolved from the OIDC token.
+          items:
+            type: string
+          title: groups
+          type: array
+        principal:
+          description: The principal resolved from the OIDC token.
+          title: principal
+          type: string
+      title: ResolveOidcIdentityResponse
+      type: object
+    redpanda.core.admin.v2.RevokeOidcSessionsRequest:
+      additionalProperties: false
+      description: RevokeOidcSessionsRequest is the request for the RevokeOidcSessions RPC.
+      title: RevokeOidcSessionsRequest
+      type: object
+    redpanda.core.admin.v2.RevokeOidcSessionsResponse:
+      additionalProperties: false
+      description: RevokeOidcSessionsResponse is the response from the RevokeOidcSessions RPC.
+      title: RevokeOidcSessionsResponse
+      type: object
+    redpanda.core.admin.v2.Role:
+      additionalProperties: false
+      description: The Role resource represents a security role with associated members.
+      properties:
+        members:
+          description: The members of the Role.
+          items:
+            $ref: "#/components/schemas/redpanda.core.admin.v2.RoleMember"
+          title: members
+          type: array
+        name:
+          description: (IMMUTABLE) The name of the Role.
+          title: name
+          type: string
+      required:
+        - name
+      title: Role
+      type: object
+    redpanda.core.admin.v2.RoleGroup:
+      additionalProperties: false
+      description: RoleGroup represents a group member of a Role.
+      properties:
+        name:
+          description: The name of the group.
+          title: name
+          type: string
+      title: RoleGroup
+      type: object
+    redpanda.core.admin.v2.RoleMember:
+      additionalProperties: false
+      description: RoleMember represents a member of a Role.
+      oneOf:
+        - properties:
+            group:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.RoleGroup"
+              title: group
+          required:
+            - group
+          title: group
+        - properties:
+            user:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.RoleUser"
+              title: user
+          required:
+            - user
+          title: user
+      title: RoleMember
+      type: object
+    redpanda.core.admin.v2.RoleUser:
+      additionalProperties: false
+      description: RoleUser represents a user member of a Role.
+      properties:
+        name:
+          description: The name of the user.
+          title: name
+          type: string
+      title: RoleUser
       type: object
     redpanda.core.admin.v2.SchemaRegistrySyncOptions:
       additionalProperties: false
@@ -1301,6 +1668,35 @@ components:
           title: username
           type: string
       title: ScramConfig
+      type: object
+    redpanda.core.admin.v2.ScramCredential:
+      additionalProperties: false
+      description: The ScramCredential resource used for SCRAM authentication.
+      properties:
+        mechanism:
+          $ref: "#/components/schemas/redpanda.core.common.v1.ScramMechanism"
+          description: The SCRAM mechanism used for this credential.
+          title: mechanism
+        name:
+          description: (IMMUTABLE) The name of the SCRAM credential.
+          title: name
+          type: string
+        password:
+          description: The password for the SCRAM credential.
+          title: password
+          type: string
+          writeOnly: true
+        passwordSetAt:
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          description: |-
+            The timestamp when the password was last set.
+             For passwords set before this feature was implemented, this will return
+             the Unix epoch (1970-01-01T00:00:00Z).
+          readOnly: true
+          title: password_set_at
+      required:
+        - name
+      title: ScramCredential
       type: object
     redpanda.core.admin.v2.ScramMechanism:
       description: Valid SCRAM mechanisms
@@ -1745,7 +2141,7 @@ components:
                  - `redpanda.remote.allowgaps`
                  - `redpanda.virtual.cluster.id`
                  - `redpanda.leaders.preference`
-                 - `redpanda.cloud_topic.enabled`
+                 - `redpanda.storage.mode`
 
                  This list is a list of properties in addition to the default properties
                  that will be synced.  See `exclude_default`.
@@ -1836,6 +2232,38 @@ components:
           title: source_last_updated_timestamp
       title: TopicPartitionInformation
       type: object
+    redpanda.core.admin.v2.UpdateScramCredentialRequest:
+      additionalProperties: false
+      description: |-
+        UpdateScramCredentialRequest is the request for the UpdateScramCredential
+         RPC.
+      properties:
+        scramCredential:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          description: The SCRAM credential to update.
+          title: scram_credential
+        updateMask:
+          $ref: "#/components/schemas/google.protobuf.FieldMask"
+          description: |-
+            The list of fields to update
+             See [AIP-134](https://google.aip.dev/134) for how to use `field_mask`
+          title: update_mask
+      required:
+        - scramCredential
+      title: UpdateScramCredentialRequest
+      type: object
+    redpanda.core.admin.v2.UpdateScramCredentialResponse:
+      additionalProperties: false
+      description: |-
+        UpdateScramCredentialResponse is the response from the UpdateScramCredential
+         RPC.
+      properties:
+        scramCredential:
+          $ref: "#/components/schemas/redpanda.core.admin.v2.ScramCredential"
+          description: The updated SCRAM credential.
+          title: scram_credential
+      title: UpdateScramCredentialResponse
+      type: object
     redpanda.core.admin.v2.UpdateShadowLinkRequest:
       additionalProperties: false
       description: Updates a shadow link
@@ -1912,6 +2340,14 @@ components:
         - ACL_RESOURCE_SR_REGISTRY
         - ACL_RESOURCE_SR_ANY
       title: ACLResource
+      type: string
+    redpanda.core.common.v1.ScramMechanism:
+      description: Valid SCRAM mechanisms
+      enum:
+        - SCRAM_MECHANISM_UNSPECIFIED
+        - SCRAM_MECHANISM_SCRAM_SHA_256
+        - SCRAM_MECHANISM_SCRAM_SHA_512
+      title: ScramMechanism
       type: string
     redpanda.core.common.v1.TLSFileSettings:
       additionalProperties: false
@@ -1994,11 +2430,11 @@ components:
 info:
   description: Redpanda Admin API specification
   title: Redpanda Admin API
-  version: v2.0.0
+  version: "26.1"
   x-admin-api-major: v2.0.0
-  x-generated-at: 2026-01-16T14:02:58.802Z
+  x-generated-at: 2026-03-14T00:12:06.766Z
   x-generator: redpanda-docs-openapi-bundler
-  x-redpanda-core-version: v25.3.5
+  x-redpanda-core-version: v26.1.1-rc2
 openapi: 3.1.0
 paths:
   /redpanda.core.admin.v2.BrokerService/GetBroker:
@@ -2111,6 +2547,560 @@ paths:
       summary: ListKafkaConnections
       tags:
         - ClusterService
+  /redpanda.core.admin.v2.SecurityService/AddRoleMembers:
+    post:
+      description: |-
+        Add members to a Role. If any members are already part of the role, they
+         are ignored. Returns the updated Role resource.
+      operationId: redpanda.core.admin.v2.SecurityService.AddRoleMembers
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.AddRoleMembersRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.AddRoleMembersResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: AddRoleMembers
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/CreateRole:
+    post:
+      description: Create a new Role resource.
+      operationId: redpanda.core.admin.v2.SecurityService.CreateRole
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.CreateRoleRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.CreateRoleResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: CreateRole
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/CreateScramCredential:
+    post:
+      description: Create a SCRAM credential.
+      operationId: redpanda.core.admin.v2.SecurityService.CreateScramCredential
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.CreateScramCredentialRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.CreateScramCredentialResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: CreateScramCredential
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/DeleteRole:
+    post:
+      description: Delete a Role resource by name.
+      operationId: redpanda.core.admin.v2.SecurityService.DeleteRole
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.DeleteRoleRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.DeleteRoleResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: DeleteRole
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/DeleteScramCredential:
+    post:
+      description: Delete a SCRAM credential.
+      operationId: redpanda.core.admin.v2.SecurityService.DeleteScramCredential
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.DeleteScramCredentialRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.DeleteScramCredentialResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: DeleteScramCredential
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/GetRole:
+    post:
+      description: Retrieve a Role resource by name.
+      operationId: redpanda.core.admin.v2.SecurityService.GetRole
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.GetRoleRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.GetRoleResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: GetRole
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/GetScramCredential:
+    post:
+      description: Retrieve a SCRAM credential.
+      operationId: redpanda.core.admin.v2.SecurityService.GetScramCredential
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.GetScramCredentialRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.GetScramCredentialResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: GetScramCredential
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/ListCurrentUserRoles:
+    post:
+      description: |-
+        Gets a list of Role names that the current authenticated user is a member
+         of on the current Redpanda broker.  This is useful for clients to
+         determine their own permissions.
+      operationId: redpanda.core.admin.v2.SecurityService.ListCurrentUserRoles
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.ListCurrentUserRolesRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.ListCurrentUserRolesResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: ListCurrentUserRoles
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/ListRoles:
+    post:
+      description: List all Role resources.
+      operationId: redpanda.core.admin.v2.SecurityService.ListRoles
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.ListRolesRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.ListRolesResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: ListRoles
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/ListScramCredentials:
+    post:
+      description: List all SCRAM credentials.
+      operationId: redpanda.core.admin.v2.SecurityService.ListScramCredentials
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.ListScramCredentialsRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.ListScramCredentialsResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: ListScramCredentials
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/RefreshOidcKeys:
+    post:
+      description: |-
+        Refresh cached OpenID Connect (OIDC) signing keys across the cluster so
+         newly issued or rotated keys are recognized.
+      operationId: redpanda.core.admin.v2.SecurityService.RefreshOidcKeys
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.RefreshOidcKeysRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.RefreshOidcKeysResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: RefreshOidcKeys
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/RemoveRoleMembers:
+    post:
+      description: |-
+        Remove members from a Role. If any members are not part of the role, they
+         are ignored. Returns the updated Role resource.
+      operationId: redpanda.core.admin.v2.SecurityService.RemoveRoleMembers
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.RemoveRoleMembersRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.RemoveRoleMembersResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: RemoveRoleMembers
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/ResolveOidcIdentity:
+    post:
+      description: |-
+        Validate an `Authorization` header `Bearer` token and return the mapped
+         principal and token expiry time.
+      operationId: redpanda.core.admin.v2.SecurityService.ResolveOidcIdentity
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.ResolveOidcIdentityRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.ResolveOidcIdentityResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: ResolveOidcIdentity
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/RevokeOidcSessions:
+    post:
+      description: |-
+        Refresh cached OpenID Connect (OIDC) signing keys and revoke all active
+         OIDC sessions across the cluster. Clients authenticated with
+         `OAUTHBEARER` must re-authenticate.
+      operationId: redpanda.core.admin.v2.SecurityService.RevokeOidcSessions
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.RevokeOidcSessionsRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.RevokeOidcSessionsResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: RevokeOidcSessions
+      tags:
+        - SecurityService
+  /redpanda.core.admin.v2.SecurityService/UpdateScramCredential:
+    post:
+      description: Update a SCRAM credential.
+      operationId: redpanda.core.admin.v2.SecurityService.UpdateScramCredential
+      parameters:
+        - in: header
+          name: Connect-Protocol-Version
+          required: true
+          schema:
+            $ref: "#/components/schemas/connect-protocol-version"
+        - in: header
+          name: Connect-Timeout-Ms
+          schema:
+            $ref: "#/components/schemas/connect-timeout-header"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/redpanda.core.admin.v2.UpdateScramCredentialRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/redpanda.core.admin.v2.UpdateScramCredentialResponse"
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connect.error"
+          description: Error
+      summary: UpdateScramCredential
+      tags:
+        - SecurityService
   /redpanda.core.admin.v2.ShadowLinkService/CreateShadowLink:
     post:
       description: Creates a new shadow link between clusters.

--- a/admin/v2-overlays/add-endpoint-versioning.yaml
+++ b/admin/v2-overlays/add-endpoint-versioning.yaml
@@ -41,3 +41,50 @@ actions:
   - target: "$.paths['/redpanda.core.admin.v2.ShadowLinkService/UpdateShadowLink'].post"
     update:
       x-state: "Added in v25.3"
+
+# 26.1 endpoints
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/AddRoleMembers'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/CreateRole'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/CreateScramCredential'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/DeleteRole'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/DeleteScramCredential'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/GetRole'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/GetScramCredential'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/ListCurrentUserRoles'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/ListRoles'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/ListScramCredentials'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/RefreshOidcKeys'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/RemoveRoleMembers'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/ResolveOidcIdentity'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/RevokeOidcSessions'].post"
+    update:
+      x-state: "Added in v26.1"
+  - target: "$.paths['/redpanda.core.admin.v2.SecurityService/UpdateScramCredential'].post"
+    update:
+      x-state: "Added in v26.1"

--- a/admin/v2-overlays/create-and-update-tags.yaml
+++ b/admin/v2-overlays/create-and-update-tags.yaml
@@ -16,6 +16,9 @@ actions:
       - name: ClusterService
         description: |-
           ClusterService provides information about the Redpanda cluster as a whole, such as its configuration, status, and client connections.
+      - name: SecurityService
+        description: |-
+          Use SecurityService to manage SCRAM credentials, role-based access control (RBAC), and OpenID Connect (OIDC) operations.
       - name: ShadowLinkService
         description: |-
           Use ShadowLinkService to manage shadow links between clusters for disaster recovery.


### PR DESCRIPTION
This pull request updates the OpenAPI overlays to introduce and document the new `SecurityService` in the admin v2 API, along with its endpoints for role-based access control (RBAC), SCRAM credential management, and OpenID Connect (OIDC) operations. The changes add metadata and versioning information for these endpoints, making them available in API version 26.1.

**API Documentation Updates:**

* Added a new `SecurityService` entry to the service descriptions, explaining its purpose for managing SCRAM credentials, RBAC, and OIDC operations.

**Endpoint Versioning:**

* Marked 15 new `SecurityService` endpoints as "Added in v26.1", covering operations for roles, SCRAM credentials, and OIDC-related actions.